### PR TITLE
Gnome-40.4 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ mkdir -p ~/.local/share/gnome-shell/extensions
 git clone https://github.com/saschahagedorn-f3/gnome-globalprotect ~/.local/share/gnome-shell/extensions/gnomeglobalprotect@sascha.hagedorn.form3.tech
 ```
 
+Confirm PanGPUI is set as a startup program:
+
+```
+gnome-session-properties
+```
+
+Confirm that PanGPUI is in the list of startup programs and is checked. If not, add a new program with the following:
+
+```
+Name: PanGPUI
+Command: /opt/paloaltonetworks/globalprotect/PanGPUI
+```
+
+> **_NOTE:_** Failing to set PanGPUI as a startup program can result in gnome freezing when you click on the GlobalProtect Icon.
+
+
 Enable the extension:
 
 ```

--- a/extension.js
+++ b/extension.js
@@ -103,6 +103,12 @@ const GlobalProtectUILauncher = new Lang.Class({
         if (this.connectionMonitor != null) {
             clearInterval(this.connectionMonitor);
         }
+
+        if (this.launcherButton != null) {
+            this.launcherButton.remove_child(this.icon);
+            this.launcherButton.destroy();
+            this.launcherButton = null;
+        }
     }
 });
 

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,7 @@
   "description": "Launch GlobalProtect UI",
   "uuid": "gnomeglobalprotect@sascha.hagedorn.form3.tech",
   "shell-version": [
-    "3.36"
+    "3.36",
+    "40.4"
   ]
 }


### PR DESCRIPTION
List of changes:
* Added Gnome-40.4 to the list of supported versions in metadata.json.
* Updated installations steps in README to include checking that the PanGPUI is a startup application. (Failing to do so will result in Gnome freezing when you click on the icon).
* Added launcherButton cleanup to destroy function in order to allow disabling and then re-enabling the extension without needing to restart the gnome shell.